### PR TITLE
allow to access mobile internet connection while connected to sonde

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -1689,6 +1689,11 @@ void startAP() {
   Serial.println("Activating access point mode");
   wifi_state = WIFI_APMODE;
   WiFi.softAP(networks[0].id.c_str(), networks[0].pw.c_str());
+  
+  Serial.println("Wait 100 ms for AP_START...");
+  delay(100);
+  Serial.println(WiFi.softAPConfig(IPAddress (192,168,4,1), IPAddress (0,0,0,0), IPAddress (255,255,255,0)) ? "Ready" : "Failed!");
+  
   IPAddress myIP = WiFi.softAPIP();
   String myIPstr = myIP.toString();
   sonde.setIP(myIPstr.c_str(), true);


### PR DESCRIPTION
Before: no internet connection available while connected
solution iOS: set manual ip/subnet (192.168.4.2/255.255.255.0) with no gateway
solution Android: unknown (manual ip/subnet requires valid gateway ip)

Now: no gateway is set
iOS: "no internet connection available" - automatically uses mobile data
Android: question: no internet connection is available - using wifi? - confirm (and check remember setting). device uses mobile data