### PR TITLE
Bugfixes

### DIFF
--- a/libraries/SondeLib/Sonde.cpp
+++ b/libraries/SondeLib/Sonde.cpp
@@ -383,7 +383,14 @@ void Sonde::setup() {
 		Serial.print("Invalid rxtask.currentSonde: ");
 		Serial.println(rxtask.currentSonde);
 		rxtask.currentSonde = 0;
-	}
+    for(int i=0; i<config.maxsonde - 1; i++) {
+      if(!sondeList[rxtask.currentSonde].active) {
+        rxtask.currentSonde++;
+        if(rxtask.currentSonde>=nSonde) rxtask.currentSonde=0;
+      }
+    }
+    sonde.currentSonde = rxtask.currentSonde;
+  }
 
 	// update receiver config
 	Serial.print("\nSonde::setup() on sonde index ");

--- a/libraries/SondeLib/Sonde.cpp
+++ b/libraries/SondeLib/Sonde.cpp
@@ -345,7 +345,7 @@ void Sonde::nextConfig() {
 		currentSonde=0;
 	}
 	// Skip non-active entries (but don't loop forever if there are no active ones)
-	for(int i=0; i<config.maxsonde; i++) {
+	for(int i=0; i<config.maxsonde - 1; i++) {
 		if(!sondeList[currentSonde].active) {
 			currentSonde++;
 			if(currentSonde>=nSonde) currentSonde=0;
@@ -357,7 +357,7 @@ void Sonde::nextRxSonde() {
 	if(rxtask.currentSonde>=nSonde) {
 		rxtask.currentSonde=0;
 	}
-	for(int i=0; i<config.maxsonde; i++) {
+	for(int i=0; i<config.maxsonde - 1; i++) {
 		if(!sondeList[rxtask.currentSonde].active) {
 			rxtask.currentSonde++;
 			if(rxtask.currentSonde>=nSonde) rxtask.currentSonde=0;


### PR DESCRIPTION
- avoid skipping one QRG in loop / button when none is enabled
- starting with first enabled QRG on powerup instead of first in QRG-list