### PR TITLE
SondeHub Uploading - Fix Chase Car Property

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3065,7 +3065,7 @@ void sondehub_station_update(WiFiClient *client, struct st_sondehub *conf) {
     sprintf(w,
             "\"uploader_position\": [%.6f,%.6f,%d],"
             "\"uploader_antenna\": \"%s\","
-            "\"mobile\": \"true\""
+            "\"mobile\": true"
             "}",
             gpsPos.lat, gpsPos.lon, gpsPos.alt, conf->antenna);
   }


### PR DESCRIPTION
I'm sorry for opening another request but it seems I was sending a string value when I should have been sending a boolean which meant while the data was being logged it was not appearing on the SondeHub tracker. This quick-fix changes that and I have tested that I now appear on the map.