### PR TITLE
Sondehub fix sending optional

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3120,7 +3120,7 @@ void sondehub_station_update(WiFiClient *client, struct st_sondehub *conf) {
   w += strlen(w);
 
   // Only send email if provided
-  if (conf->email != '\0') {
+  if (strlen(conf->email) != 0) {
     sprintf(w,
           "\"uploader_contact_email\": \"%s\",",
           conf->email);
@@ -3128,7 +3128,7 @@ void sondehub_station_update(WiFiClient *client, struct st_sondehub *conf) {
   }
 
   // Only send antenna if provided
-  if (conf->antenna != '\0') {
+  if (strlen(conf->antenna) != 0) {
     sprintf(w,
           "\"uploader_antenna\": \"%s\",",
           conf->antenna);
@@ -3346,7 +3346,7 @@ void sondehub_send_data(WiFiClient * client, SondeInfo * s, struct st_sondehub *
   }
 
   // Only send antenna if provided
-  if (conf->antenna != '\0') {
+  if (strlen(conf->antenna) != 0) {
     sprintf(w,
           "\"uploader_antenna\": \"%s\",",
           conf->antenna);

--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3338,8 +3338,8 @@ void sondehub_send_data(WiFiClient * client, SondeInfo * s, struct st_sondehub *
   // Only send temp & humidity if provided
   if (((int)s->temperature != 0) && ((int)s->relativeHumidity != 0)) {
     sprintf(w,
-            "\"temp\": %.1f,"
-            "\"humidity\": %.1f,",
+            "\"temp\": %.3f,"
+            "\"humidity\": %.3f,",
             float(s->temperature), float(s->relativeHumidity)
            );
     w += strlen(w);


### PR DESCRIPTION
This should ensure that antenna and email are only sent if configured by user