### PR TITLE
SondeHub include Burst Timer RS41

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3693,27 +3693,25 @@ void sondehub_send_data(WiFiClient * client, SondeInfo * s, struct st_sondehub *
 
   // Only send temp if provided
   if ((int)s->temperature != 0) {
-    sprintf(w,
-            "\"temp\": %.3f,",
-            float(s->temperature)
-           );
+    sprintf(w, "\"temp\": %.3f,", float(s->temperature));
     w += strlen(w);
   }
 	
   // Only send humidity if provided
   if ((int)s->relativeHumidity != 0) {
-    sprintf(w,
-            "\"humidity\": %.3f,",
-            float(s->relativeHumidity)
-           );
+    sprintf(w, "\"humidity\": %.3f,", float(s->relativeHumidity));
+    w += strlen(w);
+  }
+	
+  // Only send burst timer if provided
+  if ((int)s->burstKT < 30600) {
+    sprintf(w, "\"burst_timer\": %d,", (int)s->burstKT);
     w += strlen(w);
   }
 
   // Only send antenna if provided
   if (strlen(conf->antenna) != 0) {
-    sprintf(w,
-            "\"uploader_antenna\": \"%s\",",
-            conf->antenna);
+    sprintf(w, "\"uploader_antenna\": \"%s\",", conf->antenna);
     w += strlen(w);
   }
 

--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3699,8 +3699,8 @@ void sondehub_send_data(WiFiClient * client, SondeInfo * s, struct st_sondehub *
     w += strlen(w);
   }
 	
-  // Only send burst timer if provided
-  if ((int)s->burstKT < 30600) {
+  // Only send burst timer if RS41
+  if (realtype == STYPE_RS41) {
     sprintf(w, "\"burst_timer\": %d,", (int)s->burstKT);
     w += strlen(w);
   }

--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3699,8 +3699,8 @@ void sondehub_send_data(WiFiClient * client, SondeInfo * s, struct st_sondehub *
     w += strlen(w);
   }
 	
-  // Only send burst timer if RS41
-  if (realtype == STYPE_RS41) {
+  // Only send burst timer if RS41 and not 0
+  if ((realtype == STYPE_RS41) && ((int)s->burstKT != 0)) {
     sprintf(w, "\"burst_timer\": %d,", (int)s->burstKT);
     w += strlen(w);
   }

--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -3410,17 +3410,13 @@ void sondehub_station_update(WiFiClient *client, struct st_sondehub *conf) {
 
   // Only send email if provided
   if (strlen(conf->email) != 0) {
-    sprintf(w,
-            "\"uploader_contact_email\": \"%s\",",
-            conf->email);
+    sprintf(w, "\"uploader_contact_email\": \"%s\",", conf->email);
     w += strlen(w);
   }
 
   // Only send antenna if provided
   if (strlen(conf->antenna) != 0) {
-    sprintf(w,
-            "\"uploader_antenna\": \"%s\",",
-            conf->antenna);
+    sprintf(w, "\"uploader_antenna\": \"%s\",", conf->antenna);
     w += strlen(w);
   }
 
@@ -3718,9 +3714,7 @@ void sondehub_send_data(WiFiClient * client, SondeInfo * s, struct st_sondehub *
   // We send GPS position: (a) in CHASE mode, (b) in AUTO mode if no fixed location has been specified in config
   if (chase == SH_LOC_CHASE) {
     if (gpsPos.valid && gpsPos.lat != 0 && gpsPos.lon != 0) {
-      sprintf(w,
-              "\"uploader_position\": [%.6f,%.6f,%d]",
-              gpsPos.lat, gpsPos.lon, gpsPos.alt);
+      sprintf(w, "\"uploader_position\": [%.6f,%.6f,%d]", gpsPos.lat, gpsPos.lon, gpsPos.alt);
     } else {
       sprintf(w, "\"uploader_position\": [null,null,null]");
     }


### PR DESCRIPTION
I noticed that we already decode this and display it on the web interface so figured it would be good to include it in the SondeHub upload. I hope my understanding of the value only being valid when it is under 30600 is correct. I haven't been able to test this.