### PR TITLE
Small fix to sonde_id field

### DIFF
--- a/RX_FSK/data/livemap.js
+++ b/RX_FSK/data/livemap.js
@@ -86,8 +86,10 @@ headtxt = function(data,stat) {
     $('#sonde_rssi').html(data.rssi / 2 );
     $('#sonde_detail').show();
   } else {
+    if (!data.id) {
     $('#sonde_id').html(data.launchsite.trim());
     // $('#sonde_detail').hide();
+    }
   }
   $('#sonde_freq').html(data.freq);
   $('#sonde_type').html(data.type);


### PR DESCRIPTION
This makes sure that sonde_id doesn't go back to the Launch Site name if there is something in data.id when status is blinking yellow.