### PR TITLE
Make telemetry values available on device display

### DIFF
--- a/RX_FSK/src/Display.cpp
+++ b/RX_FSK/src/Display.cpp
@@ -809,6 +809,10 @@ void Display::parseDispElement(char *text, DispEntry *de)
 		de->extra = strdup(text+1);
 		//Serial.printf("parsing 'f' entry: extra is '%s'\n", de->extra);
 		break;
+	case 'm':
+		de->func = disp.drawTelemetry;
+		de->extra = strdup(text+1);
+		break;
 	case 'n':
 		// IP address / small always uses tiny font on TFT for backward compatibility
 		// Large font can be used arbitrarily
@@ -1283,6 +1287,31 @@ void Display::drawSite(DispEntry *de) {
 	drawString(de, buf);
 }
 void Display::drawTelemetry(DispEntry *de) {
+	rdis->setFont(de->fmt);
+	float value=0;
+	switch(de->extra[0]) {
+	case 't':
+		value = sonde.si()->d.temperature;
+		if(value!=0xffff) snprintf(buf, 8, "%3.2f", value);
+		else strcpy(buf, "       ");
+		break;
+	case 'p':
+		value = sonde.si()->d.pressure;
+		if(value!=0xffff) snprintf(buf, 7, "%4.2f", value);
+		else strcpy(buf, "      ");
+		break;
+	case 'h':
+		value = sonde.si()->d.relativeHumidity;
+		if(value!=0xffff) snprintf(buf, 5, "%3.1f", value);
+		else strcpy(buf, "     ");
+		break;
+	case 'b':
+		value = sonde.si()->d.batteryVoltage;
+		if(value!=0xffff) snprintf(buf, 5, "%1.2f", value);
+		else strcpy(buf, "    ");
+		break;
+	}
+	drawString(de,buf);
 }
 
 void Display::drawKilltimer(DispEntry *de) {


### PR DESCRIPTION
This is probably not the cleanest coding so apologies in advance.
An update of the description in screens files would also be needed.
Tested on TTGO.
![image](https://user-images.githubusercontent.com/2545460/134677802-dc25315d-9074-4cf7-b9a3-33b50c55e180.png)
