### PR TITLE
Remove RS92-NGP Support Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ for details on supported boards, and additional setup instructions.
 
 Manufacturer | Model | Position | Temperature | Humidity | Pressure
 -------------|-------|----------|-------------|----------|----------
-Vaisala | RS92-SGP/NGP | :heavy_check_mark: | :heavy_check_mark: | :x: | :x:
+Vaisala | RS92-SGP | :heavy_check_mark: | :heavy_check_mark: | :x: | :x:
 Vaisala | RS41-SG/SGP/SGM | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: (for -SGP)
 Graw | DFM06/09/17 | :heavy_check_mark: | :heavy_check_mark: | :x: | :x:
 Meteomodem | M10 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Not Sent


### PR DESCRIPTION
The RS92-NGP is a 1680 MHz device that cannot be decoded using the 433 MHz LoRa chips.