### PR TITLE
Add station identifier field to chasemapper json

### DIFF
--- a/RX_FSK/src/Chasemapper.cpp
+++ b/RX_FSK/src/Chasemapper.cpp
@@ -12,6 +12,7 @@ int Chasemapper::send(WiFiUDP &udp, SondeInfo *si) {
 		realtype = si->d.subtype == 1 ? STYPE_M10 : STYPE_M20;
 	}
 	sprintf(buf, "{ \"type\": \"PAYLOAD_SUMMARY\","
+		"\"station\": \"%s\","
 		"\"callsign\": \"%s\","
 		"\"latitude\": %.5f,"
 		"\"longitude\": %.5f,"
@@ -21,6 +22,7 @@ int Chasemapper::send(WiFiUDP &udp, SondeInfo *si) {
 		"\"time\": \"%02d:%02d:%02d\","
 		"\"model\": \"%s\","
 		"\"freq\": \"%.3f MHz\"",
+		sonde.config.mdnsname,
 		si->d.ser,
 		si->d.lat,
 		si->d.lon,


### PR DESCRIPTION
Feel free to deny since it technically breaks "spec". radiosonde_auto_rx also sends that field (https://github.com/projecthorus/radiosonde_auto_rx/blob/d3b2d06a098406c6232799e385752693d0c3f0d8/auto_rx/autorx/ozimux.py#L157).
I use it to differentiate between packets coming from different receivers for data logging purposes. Doesn't seem to be used in chasemapper (yet).