### PR TITLE
Add Display Elements for GPS speed of the board in km/h and m/s 

### DIFF
--- a/RX_FSK/src/Display.cpp
+++ b/RX_FSK/src/Display.cpp
@@ -1661,6 +1661,18 @@ void Display::drawGPS(DispEntry *de) {
 	case 'E':
 		// elevation
 		break;
+	case 'S':
+		// Speed (in m/s)
+		snprintf(buf, 16, "%.2f", gpsPos.speed);
+		drawString(de, buf);
+		rdis->drawTile(de->x+5,de->y,2,ms_tiles);
+		break;	
+	case 'K':
+		// speed (in Km/h)
+		snprintf(buf, 16, "%.2f", gpsPos.speed * 3.6 );
+		drawString(de, buf);
+		rdis->drawTile(de->x+5,de->y,2,kmh_tiles);
+		break;			
 	}
 }
 

--- a/RX_FSK/src/posinfo.cpp
+++ b/RX_FSK/src/posinfo.cpp
@@ -105,6 +105,7 @@ void gpsTask(void *parameter) {
         if (gpsPos.valid) {
           gpsPos.lon = nmea.getLongitude() * 0.000001;
           gpsPos.lat = nmea.getLatitude() * 0.000001;
+          gpsPos.speed = nmea.getSpeed() / 1000.0 * 0.514444; // speed is in m/s  nmea.getSpeed is in 0.001 knots
           long alt = 0;
           nmea.getAltitude(alt);
           gpsPos.alt = (int)(alt / 1000);


### PR DESCRIPTION
New display Elements available to show the speed of movement of the boards internal GPS Receiver. 
The speed is transmitted anyways in an NMEA GP_RMC message from the GPS Module, so there is only minor computational effort to convert the provided knots into more useful m/s and km/h.
Useful for evaluation and testing even without an active sonde present.

for use in screens.txt:
gS to display speed in m/s ("S"peed)
gK to display speed in km/h ("K"m/h)