### PR TITLE
issue 433 set sum to zero in humidity correction

### DIFF
--- a/RX_FSK/src/RS41.cpp
+++ b/RX_FSK/src/RS41.cpp
@@ -661,6 +661,7 @@ float GetRAHumidity( uint32_t humCurrent, uint32_t humMin, uint32_t humMax, floa
       powc *= Cp;
    }
    Cp -= sum;
+   sum = 0.0;
 
    float xj = 1.0f;
    for ( int j = 0; j < 7; j++) {


### PR DESCRIPTION
The sum is used for two separate corrections to the relative humidity calculation but was not set to zero between the corrections. This resulted in a slightly difference relative humidity calculation.