### PR TITLE
Added audio feedback of packets received with addition of a piezoe sp…

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -670,6 +670,7 @@ struct st_configitems config_list[] = {
   {"touch_thresh", 0, &sonde.config.touch_thresh},
   {"power_pout", 0, &sonde.config.power_pout},
   {"led_pout", 0, &sonde.config.led_pout},
+  {"piezoe_pout", 0, &sonde.config.piezoe_pout},
   {"gps_rxd", 0, &sonde.config.gps_rxd},
   {"gps_txd", 0, &sonde.config.gps_txd},
   {"batt_adc", 0, &sonde.config.batt_adc},
@@ -1380,6 +1381,7 @@ void touchISR2();
 
 Ticker ticker;
 Ticker ledFlasher;
+Ticker tone;
 
 #define IS_TOUCH(x) (((x)!=255)&&((x)!=-1)&&((x)&128))
 void initTouch() {
@@ -1499,6 +1501,17 @@ void flashLed(int ms) {
   if (sonde.config.led_pout >= 0) {
     digitalWrite(sonde.config.led_pout, HIGH);
     ledFlasher.once_ms(ms, ledOffCallback);
+  }
+}
+
+void toneOffCallback() {
+  ledcWriteTone(0,0);
+}
+
+void toneOn(int ms) {
+  if (sonde.config.piezoe_pout >= 0) {
+    ledcWriteTone(0,440); // 440 Hz - Middle A
+    tone.once_ms(ms, toneOffCallback);
   }
 }
 
@@ -1763,6 +1776,11 @@ void setup()
   if (sonde.config.led_pout >= 0) {
     pinMode(sonde.config.led_pout, OUTPUT);
     flashLed(1000); // testing
+  }
+
+  if (sonde.config.piezoe_pout >= 0) {
+    ledcAttachPin(sonde.config.piezoe_pout,0);
+    toneOn(1000); // testing
   }
 
   button1.pin = sonde.config.button_pin;

--- a/RX_FSK/data/cfg.js
+++ b/RX_FSK/data/cfg.js
@@ -88,6 +88,7 @@ var cfgs = [
 [ "touch_thresh", "Touch button threshold<br>(0 for calib mode)"],
 [ "power_pout", "Power control port"],
 [ "led_pout", "LED output port"],
+[ "piezoe_pout", "Piezo output port"],
 [ "gps_rxd", "GPS RXD pin (-1 to disable)"],
 [ "gps_txd", "GPS TXD pin (not really needed)"],
 [ "batt_adc", "Battery measurement pin"],

--- a/RX_FSK/data/config.txt
+++ b/RX_FSK/data/config.txt
@@ -10,6 +10,8 @@
 #button2_axp=0
 # LED port
 #led_pout=-1
+# Piezoe Speaker
+piezoe_pout=-1
 # OLED Setup is depending on hardware of LoRa board
 # TTGO v1:  SDA=4  SCL=15, RST=16 
 # TTGO v2:  SDA=21 SCL=22, RST=16

--- a/RX_FSK/src/Sonde.cpp
+++ b/RX_FSK/src/Sonde.cpp
@@ -92,6 +92,7 @@ void Sonde::defaultConfig() {
 	}
 	config.touch_thresh = 70;
 	config.led_pout = -1;
+	config.piezoe_pout = -1;
 	config.power_pout = -1;
 	config.spectrum=10;
 	// Try autodetecting board type
@@ -462,6 +463,8 @@ void Sonde::setup() {
 
 extern void flashLed(int ms);
 
+extern void toneOn(int ms);
+
 void Sonde::receive() {
 	uint16_t res = 0;
 	SondeInfo *si = &sondeList[rxtask.currentSonde];
@@ -490,6 +493,7 @@ void Sonde::receive() {
 	// state information for RX_TIMER / NORX_TIMER events
         if(res==RX_OK || res==RX_ERROR) {  // something was received...
 		flashLed( (res==RX_OK)?700:100);
+		toneOn( (res==RX_OK)?200:50);
                 if(si->lastState != 1) {
                         si->rxStart = millis();
                         si->lastState = 1;

--- a/RX_FSK/src/Sonde.h
+++ b/RX_FSK/src/Sonde.h
@@ -240,6 +240,7 @@ typedef struct st_rdzconfig {
 	int button2_axp;		// Use AXP192 power button as button2
 	int touch_thresh;		// Threshold value (0..100) for touch input button
 	int led_pout;			// POUT port number of LED (used as serial monitor)
+	int piezoe_pout;		// POUT port number of Piezoe Speaker
 	int power_pout;			// Power control pin (for Heltec v2)
 	int disptype;			// 0=OLED; 1=ILI9225
 	int oled_sda;			// OLED/TFT data pin 

--- a/RX_FSK/src/conn-mqtt.cpp
+++ b/RX_FSK/src/conn-mqtt.cpp
@@ -112,7 +112,7 @@ void MQTT::publishUptime()
     char payload[256];
     // maybe TODO: Use dynamic position if GPS is available?
     // rxlat, rxlon only if not empty
-    snprintf(payload, 256, "{\"uptime\": %lu, \"user\": \"%s\", ", millis(), sonde.config.mqtt.username);
+    snprintf(payload, 256, "{\"uptime\": %lu, \"user\": \"%s\", ", int (millis() / 1000, sonde.config.mqtt.username);
     if( !isnan(sonde.config.rxlat) && !isnan(sonde.config.rxlon) ) {
         snprintf(payload, 256, "%s\"rxlat\": %.5f, \"rxlon\": %.5f, ", payload, sonde.config.rxlat, sonde.config.rxlon);
     }

--- a/RX_FSK/version.h
+++ b/RX_FSK/version.h
@@ -1,4 +1,4 @@
 const char *version_name = "rdzTTGOsonde";
 const char *version_id = "devel20240530";
 const int SPIFFS_MAJOR=2;
-const int SPIFFS_MINOR=17;
+const int SPIFFS_MINOR=18;


### PR DESCRIPTION
Adds audio feedback (just as the LED flashes) with each received packet.

My patches are for "devel" as I havn't been working on "dev2" yet.

Pitch of tone is at 440Hz currently.

For the two boards I own, I put one lead of the piezoe speaker on ground at the other on a spare GPIO:
Lilygo TTGO LORA32 2.1_1.6, GPIO 4
Lilygo TTGO T-Beam With display added, GPIO 25

This also bumps up the filesystem version from 17 to 18 as it modifies two files on the device.  You can upload the full binary image, or just do the code update and manually edit the two files using the built editor:

1) http://x.x.x.x/edit.html?file=cfg.js
Insert next line after "led_pout"
[ "piezoe_pout", "Piezoe output port"],

2) http://x.x.x.x/edit.html?file=config.txt
Insert next line after "led_pout="
piezoe_pout=-1

I also had to do a cold reboot for the system to recognize a new configuration item.  You'll need to then populate the GPIO for piezoe_pout to a free GPIO for your device (as above) in the web page configuration.  You'll know it's working if you hear a 1 second beep during startup.

VE6END