### PR TITLE
change color of heading1 to be better visible in dark mode

### DIFF
--- a/RX_FSK/data/style.css
+++ b/RX_FSK/data/style.css
@@ -411,7 +411,10 @@ h1{
 @media (prefers-color-scheme: dark) {
   body {
     background-color: #333;
-  }   
+  }
+  h1{
+    color: #3378f6;
+  } 
   h2{
     color: white;
   }


### PR DESCRIPTION
System info heading (h1) on index.html is dark blue `#0F3376`, which is very good visible on white background in regular light color scheme. However if the system is set to dark mode the dark color scheme in style.css changes background color to dark grey. Text color is updated to be white, but heading color is still dark blue and nearly invisible.

A brighter shade of blue (`#3378f6`) is added for h1 in dark color scheme in style.css.

Heading is now visible in light as well as dark color scheme.