### PR TITLE
use fixed width for printing wifi SSIDs

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -2550,7 +2550,9 @@ void wifiConnect(int16_t res) {
   }
   WiFi.scanDelete();
   if (bestEntry >= 0) {
-    LOG_D(TAG, "WiFi Connecting BSSID: %02X:%02X:%02X:%02X:%02X:%02X SSID: %s PW %s Channel: %d (RSSI %d)\n", bestBSSID[0], bestBSSID[1], bestBSSID[2], bestBSSID[3], bestBSSID[4], bestBSSID[5], fetchWifiSSID(bestEntry), fetchWifiPw(bestEntry), bestChannel, bestRSSI);
+    LOG_D(TAG, "WiFi Connecting BSSID: %02X:%02X:%02X:%02X:%02X:%02X SSID: %s PW %s Channel: %d (RSSI %d)\n",
+      bestBSSID[0], bestBSSID[1], bestBSSID[2], bestBSSID[3], bestBSSID[4], bestBSSID[5],
+      fetchWifiSSID(bestEntry), fetchWifiPw(bestEntry), bestChannel, bestRSSI);
     wifi_state = WIFI_CONNECT;
     WiFi.begin(fetchWifiSSID(bestEntry), fetchWifiPw(bestEntry), bestChannel, bestBSSID);
   } else {
@@ -2729,7 +2731,7 @@ void loopWifiScan() {
     int n = WiFi.scanNetworks();
     for (int i = 0; i < n; i++) {
       String ssid = WiFi.SSID(i);
-      disp.rdis->drawString(0, dispys * (1 + line), ssid.c_str());
+      disp.rdis->drawString(0, dispys * (1 + line), ssid.c_str(), 16);
       line = (line + 1) % (disph / dispys);
       String mac = WiFi.BSSIDstr(i);
       const char *encryptionTypeDescription = translateEncryptionType(WiFi.encryptionType(i));


### PR DESCRIPTION
because I have some short ("dlink") and long ("ACME Industries Guest") SSIDs near me, and without using up the whole width I occationally get lines like

	dlinkIndustries Guest

as the list of networks scrolls past