### PR TITLE
Fix compile

### DIFF
--- a/RX_FSK/data/config.txt
+++ b/RX_FSK/data/config.txt
@@ -107,8 +107,8 @@ axudp.ratelimit=1
 # connect to some aprs server
 #-------------------------------#
 tcp.active=0
-tcp.host=radiosondy.info:14590
-#tcp.host2=wettersonde.net:14590
+tcp.host=radiosondy.info:14580
+#tcp.host2=wettersonde.net:14580
 # Currently this is fixed...
 # tcp.symbol=/O
 tcp.highrate=20

--- a/RX_FSK/src/Sonde.cpp
+++ b/RX_FSK/src/Sonde.cpp
@@ -328,8 +328,9 @@ void Sonde::defaultConfig() {
 	strcpy(config.udpfeed.host, "192.168.42.20:9002");
 	config.udpfeed.ratelimit= 1;
 	config.tcpfeed.active = 0;
-	strcpy(config.tcpfeed.host, "wettersonde.net:14580");
-	strcpy(config.tcpfeed.host2, "radiosondy.info:14580");
+	strcpy(config.tcpfeed.host, "radiosondy.info:14580");
+	# default config with 
+	#strcpy(config.tcpfeed.host2, "wettersonde.net:14580");
 	strcpy(config.tcpfeed.symbol, "/O");
 	config.tcpfeed.highrate = 10;
 	config.kisstnc.active = 0;

--- a/RX_FSK/src/Sonde.cpp
+++ b/RX_FSK/src/Sonde.cpp
@@ -329,8 +329,8 @@ void Sonde::defaultConfig() {
 	config.udpfeed.ratelimit= 1;
 	config.tcpfeed.active = 0;
 	strcpy(config.tcpfeed.host, "radiosondy.info:14580");
-	# default config with 
-	#strcpy(config.tcpfeed.host2, "wettersonde.net:14580");
+	// default config with 
+	// strcpy(config.tcpfeed.host2, "wettersonde.net:14580");
 	strcpy(config.tcpfeed.symbol, "/O");
 	config.tcpfeed.highrate = 10;
 	config.kisstnc.active = 0;


### PR DESCRIPTION
Found this while I was working on something else
```
RX_FSK/src/Sonde.cpp:332:11: error: invalid preprocessing directive #default
  332 |         # default config with
      |           ^~~~~~~
RX_FSK/src/Sonde.cpp:333:10: error: invalid preprocessing directive #strcpy
  333 |         #strcpy(config.tcpfeed.host2, "wettersonde.net:14580");
      |          ^~~~~~
```