### PR TITLE
MQTT Last Will and Testament

### DIFF
--- a/RX_FSK/src/conn-mqtt.cpp
+++ b/RX_FSK/src/conn-mqtt.cpp
@@ -96,7 +96,7 @@ void MQTT::updateStation( PosInfo *pi ) {
     unsigned long now = millis();
     if ( (lastMqttUptime == 0) || (now - lastMqttUptime >= sonde.config.mqtt.report_interval) ) {
       MQTT::connectToMqtt();
-      publishLwt("online");
+      // publishLwt("online");
       publishUptime();
       publishPmuInfo();
       publishGps();

--- a/RX_FSK/src/conn-mqtt.h
+++ b/RX_FSK/src/conn-mqtt.h
@@ -17,6 +17,11 @@
 #define MQTT_SEND_DEBUG 0x80
 #define MQTT_SEND_ANY (MQTT_SEND_UPTIME|MQTT_SEND_SONDE|MQTT_SEND_PMU|MQTT_SEND_GPS|MQTT_SEND_RFINFO|MQTT_SEND_DEBUG)
 
+#define MQTT_QOS_NONE 0
+#define MQTT_QOS 1
+#define MQTT_RETAIN_TRUE true
+#define MQTT_RETAIN_FALSE false
+
 class MQTT : public Conn
 {
 public:
@@ -62,6 +67,7 @@ public:
         void publishUptime();
         void publishPmuInfo();
         void publishGps();
+        void publishLwt(const char *message);
         void timeFormat();
         int mqttGate(uint flag);
         int connectToMqtt();


### PR DESCRIPTION
Register a `lost connection` message with the MQTT broker to publish if the client loses connection. Also publish `online` when the client connects and `offline` when the client politely disconnects to a `status` topic. This way you get a clue if the device was shut down or it somehow failed.

From my MQTT viewer:
```
...
[0 ] rdz_sonde_server/csk/uptime > {"uptime": 106.6, "user": "radiosonde", "time": 2025-01-02 21:23:35, "SW": "rdzTTGOsonde", "VER": "dev20250102"}
(powered off device)
[0 ] rdz_sonde_server/csk/status > lost connection
[0 ] rdz_sonde_server/csk/status > online
[0 ] rdz_sonde_server/csk/uptime > {"uptime": 15.8, "user": "radiosonde", "time": 2025-01-02 21:24:17, "SW": "rdzTTGOsonde", "VER": "dev20250102"}
...
```