### PR TITLE
report power (in watts) on the battery and vbus rails

### DIFF
--- a/RX_FSK/src/conn-mqtt.cpp
+++ b/RX_FSK/src/conn-mqtt.cpp
@@ -172,16 +172,20 @@ void MQTT::publishPmuInfo()
     float i_d = pmu->getBattDischargeCurrent();
     float i_c = pmu->getBattChargeCurrent();
     float i_batt = 0;
+    float v_batt = pmu->getBattVoltage() / 1000.;
+    float i_bus = pmu->getVbusCurrent();
+    float v_bus = pmu->getVbusVoltage() / 1000.;
+    float p_bus = i_bus * v_bus / 1000.;
 
     if (i_c)
       i_batt = i_c;
     else if (i_d)
       i_batt = -i_d;
 
+    float p_batt = i_batt * v_batt / 1000.;
     snprintf(payload, sizeof(payload),
-        "{\"I_Batt\": %.1f, \"V_Batt\": %.3f, \"I_Vbus\": %.1f, \"V_Vbus\": %.3f, \"T_sys\": %.1f}",
-        i_batt, pmu->getBattVoltage() / 1000.,
-        pmu->getVbusCurrent(), pmu->getVbusVoltage() / 1000.,
+        "{\"I_Batt\": %.1f, \"V_Batt\": %.3f, \"P_Batt\": %.3f, \"I_Vbus\": %.1f, \"V_Vbus\": %.3f,  \"P_Vbus\": %.3f, \"T_sys\": %.1f}",
+        i_batt, v_batt, p_batt, i_bus, v_bus, p_bus,
         pmu->getTemperature());
     LOG_D(TAG, "publishPmuInfo: sending %s\n", payload);
 


### PR DESCRIPTION
Looks like this (battery charging at 1W, and drawing about 1.5W over usb):

`{"I_Batt": 250.5, "V_Batt": 4.192, "P_Batt": 1.050, "I_Vbus": 300.4, "V_Vbus": 4.949,  "P_Vbus": 1.486, "T_sys": 40.1}`

Or this, charging from a solar panel:

`{"I_Batt": 796.0, "V_Batt": 3.806, "P_Batt": 3.030, "I_Vbus": 796.1, "V_Vbus": 4.690,  "P_Vbus": 3.734, "T_sys": 70.6}`