### PR TITLE
Correct representation of RSSI

### DIFF
--- a/RX_FSK/src/json.cpp
+++ b/RX_FSK/src/json.cpp
@@ -69,7 +69,7 @@ int sonde2json(char *buf, int maxlen, SondeInfo *si)
         "\"time\": %u,"
         "\"sats\": %d,"
         "\"freq\": %.2f,"
-        "\"rssi\": %d,"
+        "\"rssi\": %.1f,"
         "\"afc\": %d,"
         "\"launchKT\": %d,"
         "\"burstKT\": %d,"
@@ -85,7 +85,7 @@ int sonde2json(char *buf, int maxlen, SondeInfo *si)
         s->time,
         s->sats,
         si->freq,
-        si->rssi,
+        si->rssi/-2.0,
         si->afc,
         s->launchKT,
         s->burstKT,


### PR DESCRIPTION
SemTech data sheet says that in FSK mode, "Actual signal power is –RssiAvg/2 (dBm)"

This makes the MQTT messages (for example) to match what the app would display, eg. `-98.5` instead of `197`