### PR TITLE
Make RSSI conversion in sonde2json runtime selectable

### DIFF
--- a/RX_FSK/src/conn-mqtt.cpp
+++ b/RX_FSK/src/conn-mqtt.cpp
@@ -269,7 +269,7 @@ void MQTT::publishPacket(SondeInfo *si)
 
     char payload[1024];
     payload[0] = '{';
-    int n = sonde2json(payload+1, 1023, si);
+    int n = sonde2json(payload+1, 1023, si, true);
     if(n<0) {
 	// ERROR
         LOG_E(TAG, "publishPacket: sonde2json failed, string too long");

--- a/RX_FSK/src/json.h
+++ b/RX_FSK/src/json.h
@@ -3,6 +3,6 @@
 
 #include "Sonde.h"
 
-int sonde2json(char *buf, int maxlen, SondeInfo *si);
+int sonde2json(char *buf, int maxlen, SondeInfo *si, bool rssi_as_dbm=false);
 
 #endif


### PR DESCRIPTION
This allows the MQTT reporter to log RSSI in dBm, while not confusing existing clients like rdzwx-go (https://github.com/dl9rdz/rdzwx-go/issues/18)
