### PR TITLE
Configurable automatic reboot, from 5 minutes to 1 day

### DIFF
--- a/RX_FSK/data/cfg.js
+++ b/RX_FSK/data/cfg.js
@@ -5,6 +5,7 @@ var cfgs = [
 [ "ephftp", "FTP server for ephemeris data (RS92 decoder)"],
 [ "debug", "Debug level (0=err/1=warn/2=info/3=all;+10=color)" ],
 [ "maxsonde", "Maximum number of QRG entries (must be &leq; 50)" ],
+[ "periodic_reboot", "reboot device periodically (5-1440 minutes, 0 to disable)" ],
 [ "rxlat", "Receiver fixed latitude"],
 [ "rxlon", "Receiver fixed longitude"],
 [ "rxalt", "Receiver fixed altitude"],

--- a/RX_FSK/data/config.txt
+++ b/RX_FSK/data/config.txt
@@ -38,6 +38,7 @@ tft_orient=1
 # General config settings
 #-------------------------------#
 maxsonde=20
+periodic_reboot=0
 # debug: 0=err, 1=warn, 2=info, 3=debug; +10:use color
 debug=12
 # wifi mode: 1=client in background; 2=AP in background; 3=client on startup, ap if failure

--- a/RX_FSK/src/Sonde.cpp
+++ b/RX_FSK/src/Sonde.cpp
@@ -305,6 +305,7 @@ void Sonde::defaultConfig() {
 	config.passcode = -1;
 	strcpy(config.mdnsname, "rdzsonde");
 	config.maxsonde=15;
+	config.periodic_reboot = 0;
 	config.debug=0;
 	config.wifi=1;
 	config.display[0]=0;
@@ -350,6 +351,8 @@ extern const int N_CONFIG;
 
 void Sonde::checkConfig() {
 	if(config.maxsonde > MAXSONDE) config.maxsonde = MAXSONDE;
+	if(config.periodic_reboot<0) config.periodic_reboot = 0;
+	if(config.periodic_reboot>1440) config.periodic_reboot = 1440;
 	if(config.sondehub.fiinterval<5) config.sondehub.fiinterval = 5;
 	if(config.sondehub.fimaxdist>700) config.sondehub.fimaxdist = 700;
 	if(config.sondehub.fimaxage>48) config.sondehub.fimaxage = 48;

--- a/RX_FSK/src/Sonde.h
+++ b/RX_FSK/src/Sonde.h
@@ -295,6 +295,7 @@ typedef struct st_rdzconfig {
 	int spectrum;			// show freq spectrum for n seconds -1=disable; 0=forever
 	int marker;				// show freq marker in spectrum  0=disable
 	int maxsonde;			// number of max sonde in scan (range=1-99)
+	int periodic_reboot;	// reboot device after x minutes, 0=0ff
 	int norx_timeout;		// Time after which rx mode switches to scan mode (without rx signal)
 	int noisefloor;			// for spectrum display
 	char mdnsname[15];		// mDNS-Name, defaults to rdzsonde


### PR DESCRIPTION
One way to address dl9rdz/rdz_ttgo_sonde#476 , here's a configurable setting to periodically reboot. Minimum time is 5 minutes, maximum time is 1440 minutes. This might not be visible in the UI without a full update, but you can edit `config.txt` to add `periodic_reboot=1440` if you want a daily reboot.