### PR TITLE
add quotes to time value on 0x02 uptime MQTT message to make

### DIFF
--- a/RX_FSK/src/conn-mqtt.cpp
+++ b/RX_FSK/src/conn-mqtt.cpp
@@ -146,7 +146,7 @@ void MQTT::publishUptime()
     // maybe TODO: Use dynamic position if GPS is available?
     // rxlat, rxlon only if not empty
     snprintf(payload, 256,
-        "{\"uptime\": %.1f, \"user\": \"%s\", \"time\": %s,",
+        "{\"uptime\": %.1f, \"user\": \"%s\", \"time\": \"%s\",",
         millis() / 1000.0, sonde.config.mqtt.username, time_str );
 
     if (!isnan(sonde.config.rxlat) && !isnan(sonde.config.rxlon)) {


### PR DESCRIPTION
add quotes to time value on 0x02 uptime MQTT message to make it consistent with the time value on the the other MQTT messages and make it parse correctly as JSON.