### PR TITLE
Add scan_dwell feature to allow scan to continue after X seconds when switching to RX mode. Helpful for tracking multiple balloons.

### DIFF
--- a/RX_FSK/RX_FSK.ino
+++ b/RX_FSK/RX_FSK.ino
@@ -786,6 +786,7 @@ struct st_configitems config_list[] = {
   /* Hardware dependeing settings */
   {"disptype", 0, &sonde.config.disptype},
   {"norx_timeout", 0, &sonde.config.norx_timeout},
+  {"scan_dwell", 0, &sonde.config.scan_dwell},
   {"oled_sda", 0, &sonde.config.oled_sda},
   {"oled_scl", 0, &sonde.config.oled_scl},
   {"oled_rst", 0, &sonde.config.oled_rst},

--- a/RX_FSK/data/cfg.js
+++ b/RX_FSK/data/cfg.js
@@ -15,6 +15,7 @@ var cfgs = [
 [ "dispsaver", "Display saver (0=never/1=always/2=ifnorx [+10*n: after n sec.])" ],
 [ "dispcontrast", "OLED contrast (-1=use default; 0..255=set contrast)" ],
 [ "norx_timeout", "No-RX-timeout in seconds (-1=disabled)"],
+[ "scan_dwell", "Scan dwell time (seconds, 0=disabled) - time to stay on signal when found during scanning"],
 [ "tft_orient", "TFT orientation (0/1/2/3), OLED flip: 3"],
 [ "", "Spectrum display configuration", "https://github.com/dl9rdz/rdz_ttgo_sonde/wiki/Spectrum-configuration" ],
 [ "spectrum", "Show spectrum on start (-1=no, 0=forever, >0=time [sec])" ],

--- a/RX_FSK/data/config.txt
+++ b/RX_FSK/data/config.txt
@@ -59,6 +59,10 @@ dispsaver=0
 dispcontrast=-1
 # set to -1 to disable (used for "N" values in timers in screens.txt). Value in seconds
 norx_timeout=20
+# Time to dwell on signal when found during scanning (seconds). Set to 0 to disable.
+# If >= norx_timeout, will be reduced by 1 second to prevent conflicts.
+# If norx_timeout=1, scan_dwell will be disabled.
+scan_dwell=0
 #-------------------------------#
 # Spectrum display settings
 #-------------------------------#

--- a/RX_FSK/src/Sonde.cpp
+++ b/RX_FSK/src/Sonde.cpp
@@ -22,7 +22,7 @@
 RXTask rxtask = { -1, -1, -1, 0xFFFF, 0 };
 
 const char *evstring[]={"NONE", "KEY1S", "KEY1D", "KEY1M", "KEY1L", "KEY2S", "KEY2D", "KEY2M", "KEY2L",
-				   "VIEWTO", "RXTO", "NORXTO", "(max)"};
+				   "VIEWTO", "RXTO", "NORXTO", "SCANDWELL", "(max)"};
 
 const char *RXstr[]={"RX_OK", "RX_TIMEOUT", "RX_ERROR", "RX_UNKNOWN"};
 
@@ -166,6 +166,7 @@ void Sonde::defaultConfig() {
 	config.tft_orient = 1;
 	config.button2_axp = 0;
 	config.norx_timeout = 20;
+	config.scan_dwell = 0;
 	config.screenfile = 1;
 	config.tft_spifreq = SPI_DEFAULT_FREQ;
 	// TFT RS and CS not used for LCD, if TFT detected this will be changed below
@@ -547,6 +548,7 @@ void Sonde::setup() {
 
 	// reset rxtimer / norxtimer state
 	sonde.sondeList[sonde.currentSonde].lastState = -1;
+	sonde.sondeList[sonde.currentSonde].fromScanMode = false;
 }
 
 extern void flashLed(int ms);
@@ -589,6 +591,8 @@ void Sonde::receive() {
 		if(si->lastState != 0) {
 			si->norxStart = millis();
 			si->lastState = 0;
+			// Clear fromScanMode when losing signal
+			si->fromScanMode = false;
 		}
 	}
 	// LOG_I(TAG, "debug: res was %d, now lastState is %d\n", res, si->lastState);
@@ -603,7 +607,8 @@ void Sonde::receive() {
 	else sonde.dispsavectlON();
 	int action = (event==EVT_NONE) ? ACT_NONE : 
                      (event==EVT_RINEX) ? ACT_RINEX_UPDATE : 
-		     (event==EVT_FORMAT) ? ACT_FORMAT_SD : disp.layout->actions[event];
+		     (event==EVT_FORMAT) ? ACT_FORMAT_SD :
+		     (event==EVT_SCANDWELL) ? ACT_NEXTSONDE : disp.layout->actions[event];
 	if(action!=ACT_NONE) { LOG_I(TAG, "event %x: action is %x\n", event, action); }
 	// If action is to move to a different sonde index, we do update things here, set activate
 	// to force the sx1278 task to call sonde.setup(), and pass information about sonde to
@@ -612,12 +617,16 @@ void Sonde::receive() {
 		// handled here...
 		if(action==ACT_DISPLAY_SCANNER) {
 			// nothing to do here, be re-call setup() for M10/M20 for repeating AFC
+			// Clear fromScanMode flag when manually returning to scanner
+			sonde.sondeList[sonde.currentSonde].fromScanMode = false;
 		}
 		else {
 			if(action==ACT_NEXTSONDE||action==ACT_PREVSONDE)
 				nextRxSonde();
 			else
 				nextRxFreq( action-64 );
+			// Clear fromScanMode flag when manually changing frequency/sonde
+			sonde.sondeList[sonde.currentSonde].fromScanMode = false;
 			action = ACT_SONDE(rxtask.currentSonde);
 		}
 		if(rxtask.activate==-1) {
@@ -704,6 +713,24 @@ uint8_t Sonde::timeoutEvent(SondeInfo *si) {
 		LOG_I(TAG, "Sonde::timeoutEvent: NORX\n");
 		return EVT_NORXTO;
 	}
+	// Scan dwell timeout - only if we came from scanning and are receiving
+	if(si->lastState==1 && si->fromScanMode && config.scan_dwell > 0) {
+		// Conflict resolution: if scan_dwell >= norx_timeout, reduce by 1 second
+		// If norx_timeout == 1, disable scan_dwell
+		int effective_scan_dwell = config.scan_dwell;
+		if(config.norx_timeout > 0) {  // norx_timeout enabled (not -1)
+			if(config.norx_timeout == 1) {
+				effective_scan_dwell = -1;  // disable scan_dwell
+			} else if(effective_scan_dwell >= config.norx_timeout) {
+				effective_scan_dwell = config.norx_timeout - 1;
+			}
+		}
+		// If norx_timeout is disabled (-1), scan_dwell works normally
+		if(effective_scan_dwell > 0 && now - si->rxStart >= effective_scan_dwell * 1000) {
+			LOG_I(TAG, "Sonde::timeoutEvent: SCAN_DWELL\n");
+			return EVT_SCANDWELL;
+		}
+	}
 	return 0;
 }
 
@@ -715,6 +742,7 @@ uint8_t Sonde::updateState(uint8_t event) {
 	// In all cases (new display mode, new sonde) we reset the mode change timers
 	sonde.sondeList[sonde.currentSonde].viewStart = millis();
 	sonde.sondeList[sonde.currentSonde].lastState = -1;
+	sonde.sondeList[sonde.currentSonde].fromScanMode = false;
 
 	// Moving to a different display mode
 	if (event==ACT_DISPLAY_SPECTRUM || event==ACT_DISPLAY_WIFI) {
@@ -724,6 +752,10 @@ uint8_t Sonde::updateState(uint8_t event) {
 	int n = event;
 	if(event==ACT_DISPLAY_DEFAULT) {
 		n = config.display[1];
+		// Set fromScanMode flag if we're switching from scanner to default display
+		if(disp.layoutIdx == config.display[0]) {  // currently on scanner display
+			sonde.sondeList[sonde.currentSonde].fromScanMode = true;
+		}
 	} else if(event==ACT_DISPLAY_SCANNER) {
 		n= config.display[0];
 	} else if(event==ACT_DISPLAY_NEXT) {
@@ -781,6 +813,8 @@ void Sonde::clearAllData(SondeInfo *si) {
 	// set floats to NaN
 	si->d.lat = si->d.lon = si->d.alt = si->d.vs = si->d.hs = si->d.dir = NAN;
 	si->d.temperature = si->d.tempRHSensor = si->d.relativeHumidity = si->d.pressure = si->d.batteryVoltage = NAN;
+	// Clear scan mode flag
+	si->fromScanMode = false;
 }
 
 void Sonde::updateDisplayPos() {

--- a/RX_FSK/src/Sonde.h
+++ b/RX_FSK/src/Sonde.h
@@ -46,7 +46,7 @@ enum RxResult { RX_OK, RX_TIMEOUT, RX_ERROR, RX_UNKNOWN, RX_NOPOS };
 /* Keypress => Sonde++ / Sonde-- / Display:=N*/
 enum Events { EVT_NONE, EVT_KEY1SHORT, EVT_KEY1DOUBLE, EVT_KEY1MID, EVT_KEY1LONG,
                         EVT_KEY2SHORT, EVT_KEY2DOUBLE, EVT_KEY2MID, EVT_KEY2LONG,
-                        EVT_VIEWTO, EVT_RXTO, EVT_NORXTO,
+                        EVT_VIEWTO, EVT_RXTO, EVT_NORXTO, EVT_SCANDWELL,
 			EVT_RINEX, EVT_FORMAT,
               EVT_MAX };
 extern const char *evstring[];
@@ -142,6 +142,7 @@ typedef struct st_sondeinfo {
 	uint32_t norxStart;		// millis() timestamp of continuous no rx start
 	uint32_t viewStart;		// millis() timestamp of viewinf this sonde with current display
 	int8_t lastState;		// -1: disabled; 0: norx; 1: rx
+	bool fromScanMode;		// true if we got to RX mode via scanning
 
 	// Third part: decoded data. Clear if reception of a new sonde has started
 	SondeData d;
@@ -299,6 +300,7 @@ typedef struct st_rdzconfig {
 	int marker;				// show freq marker in spectrum  0=disable
 	int maxsonde;			// number of max sonde in scan (range=1-99)
 	int norx_timeout;		// Time after which rx mode switches to scan mode (without rx signal)
+	int scan_dwell;			// Time to dwell on signal when found during scanning (seconds)
 	int noisefloor;			// for spectrum display
 	char mdnsname[15];		// mDNS-Name, defaults to rdzsonde
 	// receiver configuration


### PR DESCRIPTION
# Multi-Balloon Tracking Feature Implementation

## Overview

This PR implements a new `scan_dwell` configuration parameter that enables multi-balloon tracking for fixed station deployments. The feature allows the receiver to automatically cycle through configured frequencies, dwelling on detected signals for a specified duration before advancing to the next frequency.

## Motivation

The existing scanner behavior permanently switches to RX mode when a signal is found, making it impossible to track multiple balloons simultaneously. Fixed station operators often want to monitor several balloons by cycling through frequencies with brief reception periods on each active signal.

## Implementation Details

### Core Functionality

- **scan_dwell**: New integer configuration parameter (seconds)
  - Default: 0 (disabled for backwards compatibility)
  - When > 0: Automatically returns to scan mode after dwelling on a signal
  - Enables cycling through multiple frequencies for multi-balloon tracking

### State Tracking

- **fromScanMode**: New boolean flag in SondeInfo struct
  - Tracks whether RX mode was entered via scanning vs manual frequency selection
  - Ensures scan_dwell timeout only applies to scan-originated reception
  - Cleared on manual operations, signal loss, and system resets

### Event System

- **EVT_SCANDWELL**: New timeout event
  - Triggers when scan_dwell period expires during scan-originated reception
  - Maps to ACT_NEXTSONDE action to advance to next frequency
  - Integrates with existing timeout/action framework

### Conflict Resolution

Automatic conflict resolution with `norx_timeout` parameter:

- If `scan_dwell >= norx_timeout`: sets effective scan_dwell to `norx_timeout - 1`
- If `norx_timeout == 1`: disables scan_dwell entirely
- If `norx_timeout == -1`: scan_dwell operates normally

This ensures scan_dwell always triggers before norx_timeout to prevent conflicts between the two timeout mechanisms.

### Configuration Integration

- Added to `config_list[]` array for automatic web interface generation
- Included in `cfg.js` with descriptive label
- Documented in `config.txt` with usage instructions
- Follows existing configuration patterns and conventions

## Usage Workflow

1. **Scanner Mode**: Iterates through configured frequencies
2. **Signal Detection**: Switches to RX mode, sets `fromScanMode = true`
3. **Dwell Period**: Receives data for `scan_dwell` seconds
4. **Auto-Advance**: Timeout triggers return to scanner, advances to next frequency
5. **Cycle Repeat**: Process continues for continuous multi-balloon monitoring

## Files Modified

### Core Implementation

- `RX_FSK/src/Sonde.h`: Added configuration field, state flag, and event enum
- `RX_FSK/src/Sonde.cpp`: Implemented timeout logic, state management, and event handling
- `RX_FSK/RX_FSK.ino`: Added configuration list entry

### Configuration System

- `RX_FSK/data/config.txt`: Added parameter documentation and default value
- `RX_FSK/data/cfg.js`: Added web interface description

### Key Functions Modified

- `timeoutEvent()`: Added scan_dwell timeout detection with conflict resolution
- `receive()`: Added event-to-action mapping and flag management
- `updateState()`: Added flag setting/clearing for display transitions
- `setup()`: Added flag initialization
- `clearAllData()`: Added flag reset

## Robust State Management

The implementation ensures `fromScanMode` is properly cleared in all scenarios:

- **Signal Loss**: Cleared when transitioning from RX to NORX state
- **Manual Operations**: Cleared on frequency changes, sonde selection, display changes
- **System Events**: Cleared during setup, initialization, and data resets
- **Error Conditions**: Cleared during timeout events and state transitions

## Backwards Compatibility

- Default `scan_dwell = 0` maintains existing behavior
- No functional changes when disabled
- Existing scanner and RX mode operations unchanged
- Configuration system automatically handles missing parameter

## Testing Considerations

- Verify multi-balloon tracking with various scan_dwell values (3-10 seconds recommended)
- Test conflict resolution with different norx_timeout settings
- Confirm proper flag management during manual operations
- Validate web interface configuration changes
- Test edge cases: single frequency, rapid signal loss, timeout conflicts

## Configuration

Set `scan_dwell` to desired dwell time in seconds via web interface under "OLED/TFT display configuration" section. Configure multiple active frequencies in QRG list and enable scanner mode for automatic operation.